### PR TITLE
Pipeline archlabel

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,12 +2,15 @@
   <modelVersion>4.0.0</modelVersion>
   <properties>
       <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+      <jenkins.version>1.651.2</jenkins.version>
+      <java.level>7</java.level>
+      <jenkins-test-harness.version>2.1</jenkins-test-harness.version>
   </properties>
 
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.644</version>
+    <version>2.3</version>
   </parent>
 
   <groupId>org.jenkins-ci.plugins</groupId>
@@ -78,16 +81,24 @@
           <scope>test</scope>
       </dependency>
     <dependency>
-      <groupId>org.jenkins-ci.main</groupId>
-      <artifactId>jenkins-core</artifactId>
-      <version>2.45</version>
-      <type>jar</type>
-    </dependency>
-    <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>matrix-project</artifactId>
       <version>1.7.1</version>
-      <type>jar</type>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-job</artifactId>
+      <version>1.14</version>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-cps</artifactId>
+      <version>1.14</version>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-step-api</artifactId>
+      <version>1.14</version>
     </dependency>
   </dependencies>
 </project>

--- a/src/main/java/org/jenkinsci/plugins/chroot/builders/ChrootBuilder.java
+++ b/src/main/java/org/jenkinsci/plugins/chroot/builders/ChrootBuilder.java
@@ -28,12 +28,9 @@ import hudson.Extension;
 import hudson.FilePath;
 import hudson.FilePath.FileCallable;
 import hudson.Launcher;
-import hudson.model.AbstractBuild;
+import hudson.Util;
 import hudson.model.AbstractProject;
 import hudson.model.AutoCompletionCandidates;
-import hudson.model.BuildListener;
-import hudson.model.Computer;
-import hudson.model.FreeStyleProject;
 import hudson.model.Run;
 import hudson.model.TaskListener;
 import hudson.remoting.VirtualChannel;
@@ -43,11 +40,12 @@ import hudson.util.FormValidation;
 import java.io.File;
 import java.io.IOException;
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
+import javax.annotation.CheckForNull;
 import javax.servlet.ServletException;
 import jenkins.tasks.SimpleBuildStep;
-import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.plugins.chroot.tools.ChrootToolset;
 import org.jenkinsci.plugins.chroot.util.ChrootUtil;
@@ -55,6 +53,7 @@ import org.jenkinsci.remoting.RoleChecker;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.AncestorInPath;
+import org.kohsuke.stapler.DataBoundSetter;
 
 /**
  *
@@ -62,39 +61,45 @@ import org.kohsuke.stapler.AncestorInPath;
  */
 public class ChrootBuilder extends Builder implements Serializable, SimpleBuildStep {
 
-    private String chrootName;
+    private final String chrootName;
     private boolean ignoreExit;
-    private List<String> additionalPackages;
+    private List<String> additionalPackages = new ArrayList<>();
     private String packagesFile;
     private boolean clear;
-    private String command;
+    private final String command;
     private boolean loginAsRoot;
     private boolean noUpdate;
     private boolean forceInstall;
 
+    @DataBoundSetter
+    public void setForceInstall(boolean forceInstall) {
+        this.forceInstall = forceInstall;
+    }
+    
     public boolean isForceInstall() {
         return forceInstall;
     }
 
+    @DataBoundSetter
+    public void setNoUpdate(boolean noUpdate) {
+        this.noUpdate = noUpdate;
+    }
+    
     public boolean isNoUpdate() {
         return noUpdate;
     }
 
     @DataBoundConstructor
-    public ChrootBuilder(String chrootName, boolean ignoreExit,
-            String additionalPackages, String packagesFile, boolean clear,
-            String command, boolean loginAsRoot, boolean noUpdate, boolean forceInstall) throws IOException {
-        this.loginAsRoot = loginAsRoot;
-        this.chrootName = chrootName;
-        this.ignoreExit = ignoreExit;
-        this.additionalPackages = ChrootUtil.splitPackages(additionalPackages);
-        this.packagesFile = packagesFile;
-        this.clear = clear;
-        this.command = command;
-        this.noUpdate = noUpdate;
-        this.forceInstall = forceInstall;
+    public ChrootBuilder(String chrootName, String command) throws IOException {
+        this.chrootName = Util.fixNull(chrootName);
+        this.command = Util.fixNull(command);
     }
 
+    @DataBoundSetter
+    public void setLoginAsRoot(boolean loginAsRoot) {
+        this.loginAsRoot = loginAsRoot;
+    }
+    
     public boolean isLoginAsRoot() {
         return loginAsRoot;
     }
@@ -107,18 +112,38 @@ public class ChrootBuilder extends Builder implements Serializable, SimpleBuildS
         return command;
     }
 
+    @DataBoundSetter
+    public void setIgnoreExit(boolean ignoreExit) {
+        this.ignoreExit = ignoreExit;
+    }
+    
     public boolean isIgnoreExit() {
         return ignoreExit;
     }
 
+    @DataBoundSetter
+    public void setAdditionalPackages(@CheckForNull String additionalPackages) {
+        this.additionalPackages = ChrootUtil.splitPackages(Util.fixNull(additionalPackages));
+    }
+    
     public String getAdditionalPackages() {
-        return StringUtils.join(additionalPackages, " ");
+        return Util.fixEmptyAndTrim(StringUtils.join(additionalPackages, " "));
     }
 
+    @DataBoundSetter
+    public void setPackagesFile(@CheckForNull String packagesFile) {
+        this.packagesFile = Util.fixNull(packagesFile);
+    }
+    
     public String getPackagesFile() {
-        return packagesFile;
+        return Util.fixEmptyAndTrim(packagesFile);
     }
 
+    @DataBoundSetter
+    public void setClear(boolean clear) {
+        this.clear = clear;
+    }
+    
     public boolean isClear() {
         return clear;
     }

--- a/src/main/java/org/jenkinsci/plugins/chroot/builders/ChrootPackageBuilder.java
+++ b/src/main/java/org/jenkinsci/plugins/chroot/builders/ChrootPackageBuilder.java
@@ -159,7 +159,7 @@ public class ChrootPackageBuilder extends Builder implements Serializable, Simpl
             listener.fatalError("Installation of chroot environment failed");
             listener.fatalError("Please check if pbuilder is installed on the selected node and that"
                     + " the user, Jenkins uses, cann run pbuilder with sudo.");
-            // return false;
+            throw new IOException("Installation of chroot environment failed");
         }
         FilePath tarBall = new FilePath(workspace.toComputer().getNode().getChannel(), installation.getHome());
 
@@ -171,7 +171,10 @@ public class ChrootPackageBuilder extends Builder implements Serializable, Simpl
             boolean ret = installation.getChrootWorker().cleanUp(build, launcher, listener, workerTarBall);
             if (ret == false) {
                 listener.fatalError("Chroot environment cleanup failed");
-                // return ret || ignoreExit;
+                if(ignoreExit)
+                    return;
+                else
+                    throw new IOException("Chroot environment cleanup failed");
             }
         }
 
@@ -184,12 +187,15 @@ public class ChrootPackageBuilder extends Builder implements Serializable, Simpl
             boolean ret = installation.getChrootWorker().updateRepositories(build, launcher, listener, workerTarBall);
             if (ret == false) {
                 listener.fatalError("Updating repository indices in chroot environment failed.");
-                // return ret || ignoreExit;
+                if(ignoreExit)
+                    return;
+                else
+                    throw new IOException("Updating repository indices in chroot environment failed.");
             }
         }
         ChrootUtil.saveDigest(workerTarBall);
         if (!installation.getChrootWorker().perform(build, workspace, launcher, listener, workerTarBall, this.archAllLabel, this.sourcePackage) && !ignoreExit)
-            throw new IOException();
+            throw new IOException("Package build failed");
     }
 
     @Extension

--- a/src/main/java/org/jenkinsci/plugins/chroot/builders/ChrootPackageBuilder.java
+++ b/src/main/java/org/jenkinsci/plugins/chroot/builders/ChrootPackageBuilder.java
@@ -29,13 +29,9 @@ import hudson.Extension;
 import hudson.FilePath;
 import hudson.FilePath.FileCallable;
 import hudson.Launcher;
-import hudson.matrix.MatrixProject;
-import hudson.model.AbstractBuild;
+import hudson.Util;
 import hudson.model.AbstractProject;
 import hudson.model.AutoCompletionCandidates;
-import hudson.model.BuildListener;
-import hudson.model.Computer;
-import hudson.model.FreeStyleProject;
 import hudson.model.Run;
 import hudson.model.TaskListener;
 import hudson.remoting.VirtualChannel;
@@ -47,14 +43,15 @@ import java.io.IOException;
 import java.io.Serializable;
 import java.util.LinkedList;
 import java.util.List;
+import javax.annotation.CheckForNull;
 import javax.servlet.ServletException;
 import jenkins.tasks.SimpleBuildStep;
-import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.plugins.chroot.tools.ChrootToolset;
 import org.jenkinsci.plugins.chroot.util.ChrootUtil;
 import org.jenkinsci.remoting.RoleChecker;
 import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.QueryParameter;
 
 /**
@@ -63,37 +60,45 @@ import org.kohsuke.stapler.QueryParameter;
  */
 public class ChrootPackageBuilder extends Builder implements Serializable, SimpleBuildStep {
 
-    private String chrootName;
+    private final String chrootName;
     private String archAllLabel;
     private boolean ignoreExit;
-    private List<String> packagesFromFile;
     private boolean clear;
-    private String sourcePackage;
+    private final String sourcePackage;
     private boolean noUpdate;
     private boolean forceInstall;
 
+    @DataBoundSetter
+    public void setForceInstall(boolean forceInstall) {
+        this.forceInstall = forceInstall;
+    }
+    
     public boolean isForceInstall() {
         return forceInstall;
     }
 
+    @DataBoundSetter
+    public void setNoUpdate(boolean noUpdate) {
+        this.noUpdate = noUpdate;
+    }
+    
     public boolean isNoUpdate() {
         return noUpdate;
     }
-
+    
     @DataBoundConstructor
-    public ChrootPackageBuilder(String chrootName, String archAllLabel, boolean ignoreExit, boolean clear,
-            String sourcePackage, boolean noUpdate, boolean forceInstall) throws IOException {
-        this.chrootName = chrootName;
-        this.archAllLabel = archAllLabel;
-        this.ignoreExit = ignoreExit;
-        this.clear = clear;
-        this.sourcePackage = sourcePackage;
-        this.noUpdate = noUpdate;
-        this.forceInstall = forceInstall;
+    public ChrootPackageBuilder(@CheckForNull String chrootName, @CheckForNull String sourcePackage) throws IOException {
+        this.chrootName = Util.fixNull(chrootName);
+        this.sourcePackage = Util.fixNull(sourcePackage);
     }
 
     public String getChrootName() {
         return chrootName;
+    }
+    
+    @DataBoundSetter
+    public void setArchAllLabel(@CheckForNull String archAllLabel) {
+        this.archAllLabel = Util.fixNull(archAllLabel);
     }
     
     public String getArchAllLabel() {
@@ -104,10 +109,20 @@ public class ChrootPackageBuilder extends Builder implements Serializable, Simpl
         return sourcePackage;
     }
 
+    @DataBoundSetter
+    public void setIgnoreExit(boolean ignoreExit) {
+        this.ignoreExit = ignoreExit;
+    }
+    
     public boolean isIgnoreExit() {
         return ignoreExit;
     }
 
+    @DataBoundSetter
+    public void setClear(boolean clear) {
+        this.clear = clear;
+    }
+    
     public boolean isClear() {
         return clear;
     }

--- a/src/main/java/org/jenkinsci/plugins/chroot/builders/ChrootPackageBuilder.java
+++ b/src/main/java/org/jenkinsci/plugins/chroot/builders/ChrootPackageBuilder.java
@@ -135,6 +135,7 @@ public class ChrootPackageBuilder extends Builder implements Serializable, Simpl
             this.target = target;
         }
 
+        @Override
         public Void invoke(File source, VirtualChannel channel) throws IOException, InterruptedException {
             FilePath _source = new FilePath(source);
             FilePath _target = new FilePath(new File(target));
@@ -142,12 +143,13 @@ public class ChrootPackageBuilder extends Builder implements Serializable, Simpl
             return null;
         }
 
+        @Override
         public void checkRoles(RoleChecker rc) throws SecurityException {
             throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
         }
     }
 
-    // @Override
+    @Override
     public void perform(Run<?, ?> build, FilePath workspace, Launcher launcher, TaskListener listener) throws InterruptedException, IOException {
         EnvVars env = build.getEnvironment(listener);
         ChrootToolset installation = ChrootToolset.getInstallationByName(env.expand(this.chrootName));

--- a/src/main/java/org/jenkinsci/plugins/chroot/extensions/MockWorker.java
+++ b/src/main/java/org/jenkinsci/plugins/chroot/extensions/MockWorker.java
@@ -123,14 +123,14 @@ public final class MockWorker extends ChrootWorker {
         FilePath script = workspace.createTextTempFile("chroot", ".sh", commands);
 
         FilePath rootDir = workspace;
-        Node node = Computer.currentComputer().getNode();
+        Node node = tarBall.toComputer().getNode();
         FilePath chrootDir = rootDir.createTempDir("chroot", "");
         FilePath resultDir = rootDir.child("result");
         FilePath buildDir = chrootDir.child("root");
         FilePath cacheDir = chrootDir.child("cache");
         FilePath default_cfg = new FilePath(chrootDir, toolName + ".cfg");
 
-        unpackChroot(Computer.currentComputer().getNode(), listener, tarBall, chrootDir);
+        unpackChroot(tarBall.toComputer().getNode(), listener, tarBall, chrootDir);
 
         String cfg_content = String.format(
                 "config_opts['basedir'] = '%s'\n"
@@ -173,14 +173,14 @@ public final class MockWorker extends ChrootWorker {
         int id = super.getUID(launcher, userName);
 
         FilePath rootDir = workspace;
-        Node node = Computer.currentComputer().getNode();
+        Node node = tarBall.toComputer().getNode();
         FilePath chrootDir = rootDir.createTempDir("chroot", "");
         FilePath resultDir = rootDir.child("result");
         FilePath buildDir = chrootDir.child("root");
         FilePath cacheDir = chrootDir.child("cache");
         FilePath default_cfg = new FilePath(chrootDir, toolName + ".cfg");
 
-        unpackChroot(Computer.currentComputer().getNode(), listener, tarBall, chrootDir);
+        unpackChroot(tarBall.toComputer().getNode(), listener, tarBall, chrootDir);
 
         String cfg_content = String.format(
                 "config_opts['basedir'] = '%s'\n"
@@ -226,13 +226,13 @@ public final class MockWorker extends ChrootWorker {
     public boolean updateRepositories(Run<?, ?> build, Launcher launcher, TaskListener log, FilePath tarBall) throws IOException, InterruptedException {
         try {
             String toolName = getToolInstanceName(launcher, log, tarBall);
-            FilePath rootDir = Computer.currentComputer().getNode().getRootPath();
+            FilePath rootDir = tarBall.toComputer().getNode().getRootPath();
             FilePath chrootDir = rootDir.createTempDir(toolName, "");
             FilePath cacheDir = chrootDir.child("cache");
             FilePath buildDir = chrootDir.child("build");
             FilePath resultDir = chrootDir.child("result");
             resultDir.mkdirs();
-            unpackChroot(Computer.currentComputer().getNode(), log, tarBall, chrootDir);
+            unpackChroot(tarBall.toComputer().getNode(), log, tarBall, chrootDir);
             ArgumentListBuilder cmd = new ArgumentListBuilder();
             FilePath default_cfg = new FilePath(chrootDir, toolName + ".cfg");
             cmd.add(getTool())
@@ -241,7 +241,7 @@ public final class MockWorker extends ChrootWorker {
                     .add("--resultdir").add(resultDir.getRemote())
                     .add("--update");
             int ret = launcher.launch().cmds(cmd).stdout(log).stderr(log.getLogger()).join();
-            packChroot(Computer.currentComputer().getNode(), log, tarBall, chrootDir);
+            packChroot(tarBall.toComputer().getNode(), log, tarBall, chrootDir);
             cmd = new ArgumentListBuilder();
             cmd.add("sudo").add("rm").add("-fr").add(chrootDir);
             ret = launcher.launch().cmds(cmd).stdout(log).stderr(log.getLogger()).join();

--- a/src/main/java/org/jenkinsci/plugins/chroot/extensions/PBuilderWorker.java
+++ b/src/main/java/org/jenkinsci/plugins/chroot/extensions/PBuilderWorker.java
@@ -221,10 +221,18 @@ public final class PBuilderWorker extends ChrootWorker {
             return false;
         }
         if(archAllLabel != null)
-            if(envVars.containsValue(archAllLabel))
-                archFlag = "-b";
-            else
-                archFlag = "-B";
+            if(archAllLabel.startsWith("__SPECIAL__")) {
+                if(archAllLabel == "__SPECIAL__arch_and_all")
+                    archFlag = "-b";
+                else if(archAllLabel == "_SPECIAL_arch")
+                    archFlag = "-B";
+            }
+            else {
+                if(envVars.containsValue(archAllLabel))
+                    archFlag = "-b";
+                else
+                    archFlag = "-B";
+            }
         ArgumentListBuilder b = new ArgumentListBuilder().add("sudo").add(getTool()).add("--build")
                 .add("--buildplace").add(buildplace.toString())
                 .add("--buildresult").add(results.toString())

--- a/src/main/java/org/jenkinsci/plugins/chroot/steps/ChrootPackageStep.java
+++ b/src/main/java/org/jenkinsci/plugins/chroot/steps/ChrootPackageStep.java
@@ -2,6 +2,7 @@ package org.jenkinsci.plugins.chroot.steps;
 
 import hudson.Extension;
 import hudson.Util;
+import hudson.util.ListBoxModel;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 import org.jenkinsci.plugins.workflow.steps.AbstractStepDescriptorImpl;
@@ -21,6 +22,7 @@ public class ChrootPackageStep extends AbstractStepImpl {
     private final @CheckForNull String sourcePackage;
     private boolean noUpdate;
     private boolean forceInstall;
+    private String archAllBehaviour;
     
     @DataBoundConstructor
     public ChrootPackageStep(@CheckForNull String chrootName, @CheckForNull String sourcePackage) {
@@ -51,13 +53,14 @@ public class ChrootPackageStep extends AbstractStepImpl {
     }
     
     @DataBoundSetter
-    public void setArchAllLabel(@CheckForNull String archAllLabel) {
-        this.archAllLabel = Util.fixNull(archAllLabel);
+    public void setArchAllBehaviour(@CheckForNull String archAllBehaviour) {
+        this.archAllBehaviour = Util.fixNull(archAllBehaviour);
     }
     
-    public @CheckForNull String getArchAllLabel() {
-        return archAllLabel;
+    public String getArchAllBehaviour() {
+        return Util.fixEmptyAndTrim(archAllBehaviour);
     }
+
 
     public @CheckForNull String getSourcePackage() {
         return sourcePackage;
@@ -94,6 +97,15 @@ public class ChrootPackageStep extends AbstractStepImpl {
         @Override
         public String getDisplayName() {
             return "Build Debian/RPM source package in a chroot";
+        }
+        
+        
+        public ListBoxModel doFillArchAllBehaviourItems() {
+            return new ListBoxModel(
+                    new ListBoxModel.Option("Default", null),
+                    new ListBoxModel.Option("All binaries","all_and_arch"),
+                    new ListBoxModel.Option("Architecture-specific binaries","arch")
+            );
         }
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/chroot/steps/ChrootPackageStep.java
+++ b/src/main/java/org/jenkinsci/plugins/chroot/steps/ChrootPackageStep.java
@@ -1,0 +1,99 @@
+package org.jenkinsci.plugins.chroot.steps;
+
+import hudson.Extension;
+import hudson.Util;
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
+import org.jenkinsci.plugins.workflow.steps.AbstractStepDescriptorImpl;
+import org.jenkinsci.plugins.workflow.steps.AbstractStepImpl;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
+
+/**
+ *
+ * @author Jo Shields
+ */
+public class ChrootPackageStep extends AbstractStepImpl {
+    private final @CheckForNull String chrootName;
+    private @CheckForNull String archAllLabel;
+    private boolean ignoreExit;
+    private boolean clear;
+    private final @CheckForNull String sourcePackage;
+    private boolean noUpdate;
+    private boolean forceInstall;
+    
+    @DataBoundConstructor
+    public ChrootPackageStep(@CheckForNull String chrootName, @CheckForNull String sourcePackage) {
+        this.chrootName = Util.fixNull(chrootName);
+        this.sourcePackage = Util.fixNull(sourcePackage);
+    }
+    
+    @DataBoundSetter
+    public void setForceInstall(boolean forceInstall) {
+        this.forceInstall = forceInstall;
+    }
+    
+    public boolean isForceInstall() {
+        return forceInstall;
+    }
+
+    @DataBoundSetter
+    public void setNoUpdate(boolean noUpdate) {
+        this.noUpdate = noUpdate;
+    }
+    
+    public boolean isNoUpdate() {
+        return noUpdate;
+    }
+    
+    public @CheckForNull String getChrootName() {
+        return chrootName;
+    }
+    
+    @DataBoundSetter
+    public void setArchAllLabel(@CheckForNull String archAllLabel) {
+        this.archAllLabel = Util.fixNull(archAllLabel);
+    }
+    
+    public @CheckForNull String getArchAllLabel() {
+        return archAllLabel;
+    }
+
+    public @CheckForNull String getSourcePackage() {
+        return sourcePackage;
+    }
+
+    @DataBoundSetter
+    public void setIgnoreExit(boolean ignoreExit) {
+        this.ignoreExit = ignoreExit;
+    }
+    
+    public boolean isIgnoreExit() {
+        return ignoreExit;
+    }
+
+    @DataBoundSetter
+    public void setClear(boolean clear) {
+        this.clear = clear;
+    }
+    
+    public boolean isClear() {
+        return clear;
+    }
+    
+    @Extension
+    public static class DescriptorImpl extends AbstractStepDescriptorImpl {
+        public DescriptorImpl() { super(ChrootPackageStepExecution.class); }
+
+        @Override
+        public String getFunctionName() {
+            return "chrootpackage";
+        }
+
+        @Nonnull
+        @Override
+        public String getDisplayName() {
+            return "Build Debian/RPM source package in a chroot";
+        }
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/chroot/steps/ChrootPackageStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/chroot/steps/ChrootPackageStepExecution.java
@@ -1,0 +1,49 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package org.jenkinsci.plugins.chroot.steps;
+
+import com.google.inject.Inject;
+import hudson.FilePath;
+import hudson.Launcher;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import org.jenkinsci.plugins.chroot.builders.ChrootPackageBuilder;
+import org.jenkinsci.plugins.workflow.steps.AbstractSynchronousNonBlockingStepExecution;
+import org.jenkinsci.plugins.workflow.steps.StepContextParameter;
+
+/**
+ *
+ * @author directhex
+ */
+public class ChrootPackageStepExecution extends AbstractSynchronousNonBlockingStepExecution<Void> {
+    
+    @StepContextParameter
+    private transient TaskListener listener;
+    
+    @StepContextParameter
+    private transient FilePath ws;
+    
+    @StepContextParameter
+    private transient Run<?,?> build;
+    
+    @StepContextParameter
+    private transient Launcher launcher;
+    
+    @Inject
+    private transient ChrootPackageStep step;
+    
+    @Override
+    protected Void run() throws Exception {
+        ChrootPackageBuilder builder = new ChrootPackageBuilder(step.getChrootName(), step.getSourcePackage());
+        builder.setArchAllLabel(step.getArchAllLabel());
+        builder.setIgnoreExit(step.isIgnoreExit());
+        builder.setClear(step.isClear());
+        builder.setNoUpdate(step.isNoUpdate());
+        builder.setForceInstall(step.isForceInstall());
+        builder.perform(build, ws, launcher, listener);
+        return null;
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/chroot/steps/ChrootPackageStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/chroot/steps/ChrootPackageStepExecution.java
@@ -38,7 +38,7 @@ public class ChrootPackageStepExecution extends AbstractSynchronousNonBlockingSt
     @Override
     protected Void run() throws Exception {
         ChrootPackageBuilder builder = new ChrootPackageBuilder(step.getChrootName(), step.getSourcePackage());
-        builder.setArchAllLabel(step.getArchAllLabel());
+        builder.setArchAllBehaviour(step.getArchAllBehaviour());
         builder.setIgnoreExit(step.isIgnoreExit());
         builder.setClear(step.isClear());
         builder.setNoUpdate(step.isNoUpdate());

--- a/src/main/java/org/jenkinsci/plugins/chroot/steps/ChrootStep.java
+++ b/src/main/java/org/jenkinsci/plugins/chroot/steps/ChrootStep.java
@@ -1,0 +1,123 @@
+package org.jenkinsci.plugins.chroot.steps;
+
+import hudson.Extension;
+import hudson.Util;
+import java.util.Arrays;
+import java.util.List;
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
+import org.apache.commons.lang.StringUtils;
+import org.jenkinsci.plugins.chroot.util.ChrootUtil;
+import org.jenkinsci.plugins.workflow.steps.AbstractStepDescriptorImpl;
+import org.jenkinsci.plugins.workflow.steps.AbstractStepImpl;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
+
+/**
+ *
+ * @author Jo Shields
+ */
+public class ChrootStep extends AbstractStepImpl {
+    private final @CheckForNull String chrootName;
+    private List<String> additionalPackages;
+    private @CheckForNull String packagesFile;
+    private boolean ignoreExit;
+    private boolean clear;
+    private final @CheckForNull String command;
+    private boolean loginAsRoot;
+    private boolean noUpdate;
+    private boolean forceInstall;
+    
+    @DataBoundConstructor
+    public ChrootStep(@CheckForNull String chrootName, @CheckForNull String command) {
+        this.chrootName = Util.fixNull(chrootName);
+        this.command = Util.fixNull(command);
+    }
+    
+    @DataBoundSetter
+    public void setForceInstall(boolean forceInstall) {
+        this.forceInstall = forceInstall;
+    }
+    
+    public boolean isForceInstall() {
+        return forceInstall;
+    }
+    
+    @DataBoundSetter
+    public void setPackagesFile(@CheckForNull String packagesFile) {
+        this.packagesFile = Util.fixNull(packagesFile);
+    }
+    
+    public @CheckForNull String getPackagesFile() {
+        return Util.fixEmptyAndTrim(packagesFile);
+    }
+    
+    @DataBoundSetter
+    public void setLoginAsRoot(boolean loginAsRoot) {
+        this.loginAsRoot = loginAsRoot;
+    }
+    
+    public boolean isLoginAsRoot() {
+        return loginAsRoot;
+    }
+
+    @DataBoundSetter
+    public void setNoUpdate(boolean noUpdate) {
+        this.noUpdate = noUpdate;
+    }
+    
+    public boolean isNoUpdate() {
+        return noUpdate;
+    }
+    
+    public @CheckForNull String getChrootName() {
+        return chrootName;
+    }
+    
+    @DataBoundSetter
+    public void setAdditionalPackages(@CheckForNull String additionalPackages) {
+        this.additionalPackages = ChrootUtil.splitPackages(Util.fixNull(additionalPackages));
+    }
+    
+    public @CheckForNull String getAdditionalPackages() {
+        return Util.fixEmptyAndTrim(StringUtils.join(additionalPackages, " "));
+    }
+
+    public @CheckForNull String getCommand() {
+        return command;
+    }
+
+    @DataBoundSetter
+    public void setIgnoreExit(boolean ignoreExit) {
+        this.ignoreExit = ignoreExit;
+    }
+    
+    public boolean isIgnoreExit() {
+        return ignoreExit;
+    }
+
+    @DataBoundSetter
+    public void setClear(boolean clear) {
+        this.clear = clear;
+    }
+    
+    public boolean isClear() {
+        return clear;
+    }
+    
+    @Extension
+    public static class DescriptorImpl extends AbstractStepDescriptorImpl {
+        public DescriptorImpl() { super(ChrootStepExecution.class); }
+
+        @Override
+        public String getFunctionName() {
+            return "chroot";
+        }
+
+        @Nonnull
+        @Override
+        public String getDisplayName() {
+            return "Run script in a chroot";
+        }
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/chroot/steps/ChrootStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/chroot/steps/ChrootStepExecution.java
@@ -1,0 +1,51 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package org.jenkinsci.plugins.chroot.steps;
+
+import com.google.inject.Inject;
+import hudson.FilePath;
+import hudson.Launcher;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import org.jenkinsci.plugins.chroot.builders.ChrootBuilder;
+import org.jenkinsci.plugins.workflow.steps.AbstractSynchronousNonBlockingStepExecution;
+import org.jenkinsci.plugins.workflow.steps.StepContextParameter;
+
+/**
+ *
+ * @author directhex
+ */
+public class ChrootStepExecution extends AbstractSynchronousNonBlockingStepExecution<Void> {
+    
+    @StepContextParameter
+    private transient TaskListener listener;
+    
+    @StepContextParameter
+    private transient FilePath ws;
+    
+    @StepContextParameter
+    private transient Run<?,?> build;
+    
+    @StepContextParameter
+    private transient Launcher launcher;
+    
+    @Inject
+    private transient ChrootStep step;
+    
+    @Override
+    protected Void run() throws Exception {
+        ChrootBuilder builder = new ChrootBuilder(step.getChrootName(), step.getCommand());
+        builder.setLoginAsRoot(step.isLoginAsRoot());
+        builder.setIgnoreExit(step.isIgnoreExit());
+        builder.setAdditionalPackages(step.getAdditionalPackages());
+        builder.setPackagesFile(step.getPackagesFile());
+        builder.setClear(step.isClear());
+        builder.setNoUpdate(step.isNoUpdate());
+        builder.setForceInstall(step.isForceInstall());        
+        builder.perform(build, ws, launcher, listener);
+        return null;
+    }
+}

--- a/src/main/resources/org/jenkinsci/plugins/chroot/builders/ChrootPackageBuilder/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/chroot/builders/ChrootPackageBuilder/config.jelly
@@ -35,6 +35,11 @@
             <f:textbox/>
         </f:entry>
     </j:if>
+    <j:if test="${it.getClass().canonicalName == 'org.jenkinsci.plugins.workflow.cps.Snippetizer'}">
+        <f:entry field="archAllBehaviour" title="Multi-architecture behaviour">
+            <f:select/>
+        </f:entry>
+    </j:if>
 <f:entry field="ignoreExit" title="Ignore exit code">
 <f:checkbox />
 </f:entry>

--- a/src/main/resources/org/jenkinsci/plugins/chroot/builders/ChrootPackageBuilder/help-archAllBehaviour.html
+++ b/src/main/resources/org/jenkinsci/plugins/chroot/builders/ChrootPackageBuilder/help-archAllBehaviour.html
@@ -18,4 +18,4 @@
  along with Chroot-plugin.  If not, see <http://www.gnu.org/licenses/>.
 -->
 
-dpkg-buildpackage by default builds all binary packages from a source package which match the current architecture, or are architecture "All". A label here will result in architecture:All packages only being built on that label.
+dpkg-buildpackage by default builds all binary packages from a source package which match the current architecture, or are architecture "All". You can change the default behaviour here, equivalent to adding a "-b" or "-B" flag to dpkg-buildpackage

--- a/src/main/resources/org/jenkinsci/plugins/chroot/steps/ChrootPackageStep/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/chroot/steps/ChrootPackageStep/config.jelly
@@ -30,9 +30,9 @@
 </f:entry>
 
 <f:advanced>
-    <j:if test="${it.getClass().canonicalName == 'hudson.matrix.MatrixProject'}">
-        <f:entry field="archAllLabel" title="Primary matrix configuration">
-            <f:textbox/>
+    <j:if test="${it.getClass().canonicalName == 'org.jenkinsci.plugins.workflow.cps.Snippetizer'}">
+        <f:entry field="archAllBehaviour" title="Multi-architecture behaviour">
+            <f:select/>
         </f:entry>
     </j:if>
 <f:entry field="ignoreExit" title="Ignore exit code">

--- a/src/main/resources/org/jenkinsci/plugins/chroot/steps/ChrootPackageStep/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/chroot/steps/ChrootPackageStep/config.jelly
@@ -1,0 +1,50 @@
+<!--
+ Copyright 2013, Roman Mohr <roman@fenkhuber.at>
+ Copyright 2016, Xamarin, Inc
+
+ This file is part of Chroot-plugin.
+
+ Chroot-plugin is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ Chroot-plugin is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with Chroot-plugin.  If not, see <http://www.gnu.org/licenses/>.
+-->
+
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+<f:entry field="chrootName" title="Chroot Environment">
+   <f:textbox />
+</f:entry>
+<f:entry field="clear" title="Clear">
+<f:checkbox />
+</f:entry>
+<f:entry field="sourcePackage" title="Source package">
+<f:textbox/>
+</f:entry>
+
+<f:advanced>
+    <j:if test="${it.getClass().canonicalName == 'hudson.matrix.MatrixProject'}">
+        <f:entry field="archAllLabel" title="Primary matrix configuration">
+            <f:textbox/>
+        </f:entry>
+    </j:if>
+<f:entry field="ignoreExit" title="Ignore exit code">
+<f:checkbox />
+</f:entry>
+<f:entry field="noUpdate" title="Do not update repository indices">
+<f:checkbox />
+</f:entry>
+<f:entry field="forceInstall" title="Force installation of packages">
+<f:checkbox />
+</f:entry>
+</f:advanced>
+
+
+</j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/chroot/steps/ChrootPackageStep/help-archAllBehaviour.html
+++ b/src/main/resources/org/jenkinsci/plugins/chroot/steps/ChrootPackageStep/help-archAllBehaviour.html
@@ -1,0 +1,21 @@
+<!--
+ Copyright 2013, Roman Mohr <roman@fenkhuber.at>
+ Copyright 2016, Xamarin, Inc
+
+ This file is part of Chroot-plugin.
+
+ Chroot-plugin is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ Chroot-plugin is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with Chroot-plugin.  If not, see <http://www.gnu.org/licenses/>.
+-->
+
+dpkg-buildpackage by default builds all binary packages from a source package which match the current architecture, or are architecture "All". You can change the default behaviour here, equivalent to adding a "-b" or "-B" flag to dpkg-buildpackage

--- a/src/main/resources/org/jenkinsci/plugins/chroot/steps/ChrootPackageStep/help-archAllLabel.html
+++ b/src/main/resources/org/jenkinsci/plugins/chroot/steps/ChrootPackageStep/help-archAllLabel.html
@@ -1,0 +1,21 @@
+<!--
+ Copyright 2013, Roman Mohr <roman@fenkhuber.at>
+ Copyright 2016, Xamarin, Inc
+
+ This file is part of Chroot-plugin.
+
+ Chroot-plugin is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ Chroot-plugin is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with Chroot-plugin.  If not, see <http://www.gnu.org/licenses/>.
+-->
+
+dpkg-buildpackage by default builds all binary packages from a source package which match the current architecture, or are architecture "All". A label here will result in architecture:All packages only being built on that label.

--- a/src/main/resources/org/jenkinsci/plugins/chroot/steps/ChrootPackageStep/help-clear.html
+++ b/src/main/resources/org/jenkinsci/plugins/chroot/steps/ChrootPackageStep/help-clear.html
@@ -1,0 +1,21 @@
+<!--
+ Copyright 2013, Roman Mohr <roman@fenkhuber.at>
+
+ This file is part of Chroot-plugin.
+
+ Chroot-plugin is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ Chroot-plugin is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with Chroot-plugin.  If not, see <http://www.gnu.org/licenses/>.
+-->
+
+Uses a fresh copied chroot tarball without packages installed from previous runs.
+The build will take longer but the build results will be more meaningful.

--- a/src/main/resources/org/jenkinsci/plugins/chroot/steps/ChrootPackageStep/help-forceInstall.html
+++ b/src/main/resources/org/jenkinsci/plugins/chroot/steps/ChrootPackageStep/help-forceInstall.html
@@ -1,0 +1,21 @@
+<!--
+ Copyright 2013, Roman Mohr <roman@fenkhuber.at>
+
+ This file is part of Chroot-plugin.
+
+ Chroot-plugin is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ Chroot-plugin is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with Chroot-plugin.  If not, see <http://www.gnu.org/licenses/>.
+-->
+
+This option allows to force the installation of the specified packages. The underlying container will do whatever it can do to fulfill this request.
+This allows actions like downgrading, installing untrusted packages, etc.

--- a/src/main/resources/org/jenkinsci/plugins/chroot/steps/ChrootPackageStep/help-ignoreExit.html
+++ b/src/main/resources/org/jenkinsci/plugins/chroot/steps/ChrootPackageStep/help-ignoreExit.html
@@ -1,0 +1,20 @@
+<!--
+ Copyright 2013, Roman Mohr <roman@fenkhuber.at>
+
+ This file is part of Chroot-plugin.
+
+ Chroot-plugin is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ Chroot-plugin is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with Chroot-plugin.  If not, see <http://www.gnu.org/licenses/>.
+-->
+
+The build will always succeed.

--- a/src/main/resources/org/jenkinsci/plugins/chroot/steps/ChrootPackageStep/help-noUpdate.html
+++ b/src/main/resources/org/jenkinsci/plugins/chroot/steps/ChrootPackageStep/help-noUpdate.html
@@ -1,0 +1,23 @@
+<!--
+ Copyright 2013, Roman Mohr <roman@fenkhuber.at>
+
+ This file is part of Chroot-plugin.
+
+ Chroot-plugin is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ Chroot-plugin is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with Chroot-plugin.  If not, see <http://www.gnu.org/licenses/>.
+-->
+
+When this option is enabled, the repository indices are only updated if extra packages are going to be installed.
+When disabling repository updates, self contained builds, which do not have to install packages, will run faster.
+
+Because packages can also be installed from commands within the buildstep, by default, the package indices are always updated.

--- a/src/main/resources/org/jenkinsci/plugins/chroot/steps/ChrootPackageStep/help-sourcePackage.html
+++ b/src/main/resources/org/jenkinsci/plugins/chroot/steps/ChrootPackageStep/help-sourcePackage.html
@@ -1,0 +1,21 @@
+<!--
+ Copyright 2013, Roman Mohr <roman@fenkhuber.at>
+ Copyright 2016, Xamarin, Inc
+
+ This file is part of Chroot-plugin.
+
+ Chroot-plugin is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ Chroot-plugin is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with Chroot-plugin.  If not, see <http://www.gnu.org/licenses/>.
+-->
+
+Enter the fully qualified path to the source package you wish to build (a .dsc or .src.rpm file) - use WORKSPACE variable for paths relative to workspace

--- a/src/main/resources/org/jenkinsci/plugins/chroot/steps/ChrootStep/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/chroot/steps/ChrootStep/config.jelly
@@ -1,0 +1,53 @@
+<!--
+ Copyright 2013, Roman Mohr <roman@fenkhuber.at>
+
+ This file is part of Chroot-plugin.
+
+ Chroot-plugin is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ Chroot-plugin is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with Chroot-plugin.  If not, see <http://www.gnu.org/licenses/>.
+-->
+
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+<f:entry field="chrootName" title="Chroot Environment">
+   <f:textbox />
+</f:entry>
+<f:entry field="clear" title="Clear">
+<f:checkbox />
+</f:entry>
+<f:entry field="loginAsRoot" title="Login as root">
+<f:checkbox />
+</f:entry>
+<f:entry field="command" title="Command">
+<f:textarea/>
+</f:entry>
+
+<f:advanced>
+<f:entry field="packagesFile" title="Requirement Files">
+<f:textbox/>
+</f:entry>
+<f:entry field="additionalPackages" title="Requirements">
+<f:textbox/>
+</f:entry>
+<f:entry field="ignoreExit" title="Ignore exit code">
+<f:checkbox />
+</f:entry>
+<f:entry field="noUpdate" title="Do not update repository indices">
+<f:checkbox />
+</f:entry>
+<f:entry field="forceInstall" title="Force installation of packages">
+<f:checkbox />
+</f:entry>
+</f:advanced>
+
+
+</j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/chroot/steps/ChrootStep/help-additionalPackages.html
+++ b/src/main/resources/org/jenkinsci/plugins/chroot/steps/ChrootStep/help-additionalPackages.html
@@ -1,0 +1,22 @@
+<!--
+ Copyright 2013, Roman Mohr <roman@fenkhuber.at>
+
+ This file is part of Chroot-plugin.
+
+ Chroot-plugin is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ Chroot-plugin is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with Chroot-plugin.  If not, see <http://www.gnu.org/licenses/>.
+-->
+
+Additional packages to install into the chroot environment by 'apt-get'.
+These packages are persisted in the tarball to speed up subsequent builds.
+If you don't want this bahaviour use the 'Clear' option.

--- a/src/main/resources/org/jenkinsci/plugins/chroot/steps/ChrootStep/help-clear.html
+++ b/src/main/resources/org/jenkinsci/plugins/chroot/steps/ChrootStep/help-clear.html
@@ -1,0 +1,21 @@
+<!--
+ Copyright 2013, Roman Mohr <roman@fenkhuber.at>
+
+ This file is part of Chroot-plugin.
+
+ Chroot-plugin is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ Chroot-plugin is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with Chroot-plugin.  If not, see <http://www.gnu.org/licenses/>.
+-->
+
+Uses a fresh copied chroot tarball without packages installed from previous runs.
+The build will take longer but the build results will be more meaningful.

--- a/src/main/resources/org/jenkinsci/plugins/chroot/steps/ChrootStep/help-forceInstall.html
+++ b/src/main/resources/org/jenkinsci/plugins/chroot/steps/ChrootStep/help-forceInstall.html
@@ -1,0 +1,21 @@
+<!--
+ Copyright 2013, Roman Mohr <roman@fenkhuber.at>
+
+ This file is part of Chroot-plugin.
+
+ Chroot-plugin is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ Chroot-plugin is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with Chroot-plugin.  If not, see <http://www.gnu.org/licenses/>.
+-->
+
+This option allows to force the installation of the specified packages. The underlying container will do whatever it can do to fulfill this request.
+This allows actions like downgrading, installing untrusted packages, etc.

--- a/src/main/resources/org/jenkinsci/plugins/chroot/steps/ChrootStep/help-ignoreExit.html
+++ b/src/main/resources/org/jenkinsci/plugins/chroot/steps/ChrootStep/help-ignoreExit.html
@@ -1,0 +1,20 @@
+<!--
+ Copyright 2013, Roman Mohr <roman@fenkhuber.at>
+
+ This file is part of Chroot-plugin.
+
+ Chroot-plugin is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ Chroot-plugin is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with Chroot-plugin.  If not, see <http://www.gnu.org/licenses/>.
+-->
+
+The build will always succeed.

--- a/src/main/resources/org/jenkinsci/plugins/chroot/steps/ChrootStep/help-loginAsRoot.html
+++ b/src/main/resources/org/jenkinsci/plugins/chroot/steps/ChrootStep/help-loginAsRoot.html
@@ -1,0 +1,21 @@
+<!--
+ Copyright 2013, Roman Mohr <roman@fenkhuber.at>
+
+ This file is part of Chroot-plugin.
+
+ Chroot-plugin is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ Chroot-plugin is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with Chroot-plugin.  If not, see <http://www.gnu.org/licenses/>.
+-->
+
+When this box is unchecked the subsequent commands are run inside chroot as a user with the same uid and gid as jenkins does.
+Whenever possible leave this box unchecked, but e. g. for testing installations it might be important to be root.

--- a/src/main/resources/org/jenkinsci/plugins/chroot/steps/ChrootStep/help-noUpdate.html
+++ b/src/main/resources/org/jenkinsci/plugins/chroot/steps/ChrootStep/help-noUpdate.html
@@ -1,0 +1,23 @@
+<!--
+ Copyright 2013, Roman Mohr <roman@fenkhuber.at>
+
+ This file is part of Chroot-plugin.
+
+ Chroot-plugin is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ Chroot-plugin is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with Chroot-plugin.  If not, see <http://www.gnu.org/licenses/>.
+-->
+
+When this option is enabled, the repository indices are only updated if extra packages are going to be installed.
+When disabling repository updates, self contained builds, which do not have to install packages, will run faster.
+
+Because packages can also be installed from commands within the buildstep, by default, the package indices are always updated.

--- a/src/main/resources/org/jenkinsci/plugins/chroot/steps/ChrootStep/help-packagesFile.html
+++ b/src/main/resources/org/jenkinsci/plugins/chroot/steps/ChrootStep/help-packagesFile.html
@@ -1,0 +1,21 @@
+<!--
+ Copyright 2013, Roman Mohr <roman@fenkhuber.at>
+
+ This file is part of Chroot-plugin.
+
+ Chroot-plugin is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ Chroot-plugin is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with Chroot-plugin.  If not, see <http://www.gnu.org/licenses/>.
+-->
+
+Enter a list of comma separated relative paths to files in the workspace, which contain additionals packages for apt-get to install.
+Such files might be placed in a git repository wich is previously checked out.


### PR DESCRIPTION
Allow Pipeline projects to optionally pass -b or -B to dpkg-buildpackage
    
The Chroot Package Builder step included a Matrix-project-only option, `archAllLabel`, which would pass extra flags when non-null. This would allow you to do a matrix job across multiple architectures, but only build the architecture-independent components once rather than on every configuration.
    
This change adds a parameter to the DSL, selectable from the snippet generator, to do the equivalent from a pipeline script (which should be highly scriptable for multiple parallel builds).

This isn't really 9 commits, it's 1 on top of https://github.com/roguishmountain/chroot-plugin/pull/2